### PR TITLE
fix: repeat random Loki version

### DIFF
--- a/marvel-champions-vt/src/components/Main/Villain/CardImage/CardImage.jsx
+++ b/marvel-champions-vt/src/components/Main/Villain/CardImage/CardImage.jsx
@@ -5,38 +5,40 @@ import { PhaseButtonsContext } from "../../../../context/PhaseButtonsContext";
 import JuggernautMomentumCounters from "./JuggernautMomentumCounters/JuggernautMomentumCounters";
 import SpiralTeleportCounters from "./SpiralTeleportCounters/SpiralTeleportCounters";
 import StatusTokens from "./StatusTokens/StatusTokens"; 
+import VillainEnum from "../../../../enum/VillainEnum";
+import PhasesEnum from "../../../../enum/PhasesEnum";
 
 function CardImage() {
   const { phase, setPhase } = useContext(PhaseButtonsContext); /* Get the phase from the context */
 
-  const villainId = useParams(); /* Get the villainId from the URL parameters */
+  const urlParams = useParams(); /* Get the villainId from the URL parameters */
 
   const [showVillainImage, setShowVillainImage] = useState(true); /* State to control the visibility of the villain image */
 
   /* Reset the phase state when the villainId changes */
   useEffect(() => {
     setPhase("default"); /* Reset phase to default */
-  }, [villainId.villainId, setPhase]);
+  }, [urlParams.villainId, setPhase]);
 
   useEffect(() => {
     /* Check if the image exists when the phase changes */
     const img = new Image();
-    img.src = `/VillainImages/${villainId.villainId}/${phase}.jpg`;
+    img.src = `/VillainImages/${urlParams.villainId}/${phase}.jpg`;
     img.onload = () => setShowVillainImage(true); /* Show the image if it loads successfully */
     img.onerror = () => setShowVillainImage(false); /* Hide the image if it fails to load */
-  }, [phase, villainId.villainId]);
+  }, [phase, urlParams.villainId]);
 
   return <section id="imagesContainer">
 
       {showVillainImage && (
-        <img id="villainImage" src={`/VillainImages/${villainId.villainId}/${phase}.jpg`} alt={`${villainId.villainId} image`} onError={() => setShowVillainImage(false)} /* The img hides if it fails to load *//>
+        <img id="villainImage" src={`/VillainImages/${urlParams.villainId}/${phase}.jpg`} alt={`${urlParams.villainId} image`} onError={() => setShowVillainImage(false)} /* The img hides if it fails to load *//>
       )}
 
       <StatusTokens />
 
-      {villainId.villainId === "juggernaut" ? <JuggernautMomentumCounters /> : null} {/* To show the counters only in the Juggernaut's page */}
+      {urlParams.villainId === VillainEnum.Juggernaut ? <JuggernautMomentumCounters /> : null} {/* To show the counters only in the Juggernaut's page */}
 
-      {villainId.villainId === "spiral" && phase.includes("B") ? <SpiralTeleportCounters /> : null} {/* To show the counters only in the Spiral's page and obly if she is in the Cornered Phase */}
+      {urlParams.villainId === VillainEnum.Spiral && phase.includes(PhasesEnum.B) ? <SpiralTeleportCounters /> : null} {/* To show the counters only in the Spiral's page and obly if she is in the Cornered Phase */}
     
     </section>;
 

--- a/marvel-champions-vt/src/components/Main/Villain/PhaseButtons/LokiButtons/LokiButtons.jsx
+++ b/marvel-champions-vt/src/components/Main/Villain/PhaseButtons/LokiButtons/LokiButtons.jsx
@@ -4,7 +4,7 @@ import { PhaseButtonsContext } from "../../../../../context/PhaseButtonsContext"
 
 function LokiButtons() { 
   /* State to keep track of the different Loki form */
-  const [remainingLokis, setRemainingLokis] = useState([
+  const [lokiList, setlokiList] = useState([
     "loki1",
     "loki2",
     "loki3",
@@ -20,18 +20,31 @@ function LokiButtons() {
   /* To save the version we want to change */
   const [actualVersion, setActualVersion] = useState();
 
+  const [noRepeatLoki, setNoRepeatLoki] = useState("")
+
   const {setPhase} = useContext(PhaseButtonsContext);
 
   /* Function to show a random version of Loki */
   const chooseRandomVillain = () => {
-    if (remainingLokis.length === 0) {
+    if (lokiList.length === 1) {
       return /* Exit if there aren't forms left */
     };
 
-    const randomIndex = Math.floor(Math.random() * remainingLokis.length); /* Get a random index from the Loki's array */
-    const randomLoki = remainingLokis[randomIndex];
+    const randomIndex = Math.floor(Math.random() * lokiList.length); /* Get a random index from the Loki's array */
+    const randomLoki = lokiList[randomIndex];
 
-    setPhase(randomLoki); /* Set the phase to the selected Loki form */
+    if(randomLoki === noRepeatLoki) { /* Repeat the process without the repeated Loki version */
+      const newLokiList = lokiList.filter(villain => villain !== randomLoki);
+      const newRandomIndex = Math.floor(Math.random() * newLokiList.length);
+      const newRandomLoki = newLokiList[newRandomIndex];
+      setPhase(newRandomLoki);
+      setNoRepeatLoki(newRandomLoki);
+    } else {
+      setPhase(randomLoki); /* Set the phase to the selected Loki form */
+      setNoRepeatLoki(randomLoki); /* Set the state with the new item we don't want to get repeated */
+    }
+
+    
   }
 
   useEffect(() => {
@@ -41,34 +54,34 @@ function LokiButtons() {
       if(actualVersion == 1) {
         if(version1Clicked) {
           /* Remove "loki1" from the array */
-          setRemainingLokis(remainingLokis.filter(villain => villain !== lokiVersion));
+          setlokiList(lokiList.filter(villain => villain !== lokiVersion));
         } else if (!version1Clicked) {
           /* Add "loki1" from the array */
-          setRemainingLokis([...remainingLokis, lokiVersion]);
+          setlokiList([...lokiList, lokiVersion]);
         }
       } else if(actualVersion == 2) {
         if(version2Clicked) {
-          setRemainingLokis(remainingLokis.filter(villain => villain !== lokiVersion));
+          setlokiList(lokiList.filter(villain => villain !== lokiVersion));
         } else if (!version2Clicked) {
-          setRemainingLokis([...remainingLokis, lokiVersion]);
+          setlokiList([...lokiList, lokiVersion]);
         }
       } else if(actualVersion == 3) {
         if(version3Clicked) {
-          setRemainingLokis(remainingLokis.filter(villain => villain !== lokiVersion));
+          setlokiList(lokiList.filter(villain => villain !== lokiVersion));
         } else if (!version3Clicked) {
-          setRemainingLokis([...remainingLokis, lokiVersion]);
+          setlokiList([...lokiList, lokiVersion]);
         }
       } else if(actualVersion == 4) {
         if(version4Clicked) {
-          setRemainingLokis(remainingLokis.filter(villain => villain !== lokiVersion));
+          setlokiList(lokiList.filter(villain => villain !== lokiVersion));
         } else if (!version4Clicked) {
-          setRemainingLokis([...remainingLokis, lokiVersion]);
+          setlokiList([...lokiList, lokiVersion]);
         }
       } else if(actualVersion == 5) {
         if(version5Clicked) {
-          setRemainingLokis(remainingLokis.filter(villain => villain !== lokiVersion));
+          setlokiList(lokiList.filter(villain => villain !== lokiVersion));
         } else if (!version5Clicked) {
-          setRemainingLokis([...remainingLokis, lokiVersion]);
+          setlokiList([...lokiList, lokiVersion]);
         }
       }
     };
@@ -78,7 +91,6 @@ function LokiButtons() {
 
 
   
-
   return <div id="lokiButtons">
 
       <article id="lokiLegend">
@@ -90,7 +102,7 @@ function LokiButtons() {
             <p>Version 1 - LOKI (1/21)</p>
             <button onClick={() => {
               setVersion1Clicked(!version1Clicked); /* Toggle the state */
-              setActualVersion(1); /* Add or remove "loki1" from remainingLokis */
+              setActualVersion(1); /* Add or remove "loki1" from lokiList */
             }} style={{backgroundColor: version1Clicked ? "green" : "red" }}>o</button>
           </div>
 

--- a/marvel-champions-vt/src/components/Main/Villain/PhaseButtons/MorlockSiegeButtons/MorlockSiegeButtons.jsx
+++ b/marvel-champions-vt/src/components/Main/Villain/PhaseButtons/MorlockSiegeButtons/MorlockSiegeButtons.jsx
@@ -3,8 +3,7 @@ import { useState, useContext } from "react";
 import { PhaseButtonsContext } from "../../../../../context/PhaseButtonsContext";
 
 function MorlockSiegeButtons() { 
-  const [villainMode, setVillainMode] = useState("normal"); /* State to hide/display the Villain's buttons */
-  const [marauders, setMarauders] = useState([
+  let defaultMarauders = [
     "arclight",
     "blockbuster",
     "chimera",
@@ -12,7 +11,9 @@ function MorlockSiegeButtons() {
     "harpoon",
     "riptide",
     "vertigo"
-  ]);
+  ];
+  const [villainMode, setVillainMode] = useState("normal"); /* State to hide/display the Villain's buttons */
+  const [marauders, setMarauders] = useState(defaultMarauders);
 
   const {setPhase} = useContext(PhaseButtonsContext);
 
@@ -33,27 +34,11 @@ function MorlockSiegeButtons() {
       <article id="MorlockSiegeModeButtons">
         <button onClick={() => {
           setVillainMode("normal");
-          setMarauders([
-            "arclight",
-            "blockbuster",
-            "chimera",
-            "greycrow",
-            "harpoon",
-            "riptide",
-            "vertigo"
-          ]); /* Reset the array to the original state */
+          setMarauders(defaultMarauders); /* Reset the array to the original state */
           }}>Normal</button>
         <button onClick={() => {
           setVillainMode("expert");
-          setMarauders([
-            "arclight",
-            "blockbuster",
-            "chimera",
-            "greycrow",
-            "harpoon",
-            "riptide",
-            "vertigo"
-          ]); /* Reset the array to the original state */
+          setMarauders(defaultMarauders); /* Reset the array to the original state */
           }}>Expert</button>
       </article>
 

--- a/marvel-champions-vt/src/components/Main/Villain/PhaseButtons/WreckingCrewButtons/WreckingCrewButtons.jsx
+++ b/marvel-champions-vt/src/components/Main/Villain/PhaseButtons/WreckingCrewButtons/WreckingCrewButtons.jsx
@@ -1,12 +1,18 @@
 import React from "react";
 import { useState, useContext } from "react";
 import { PhaseButtonsContext } from "../../../../../context/PhaseButtonsContext";
+import {DifficultyEnum, DifficultyHelper} from "../../../../../enum/DifficultyEnum";
 
 function WreckingCrewButtons() { 
+  // Cgoob
+  // const [difficulty, setDifficulty] = useState(DifficultyEnum.Normal);
+  // let villains = ['wrecker', 'thunderball', 'piledriver', 'bulldozer'];
+
   const [showNormalButtons, setShowNormalButtons] = useState(false); /* State to hide/display the Normal mode buttons */
   const [showExpertButtons, setShowExpertButtons] = useState(false); /* State to hide/display the Expert mode buttons */
 
   const {setPhase} = useContext(PhaseButtonsContext);
+
 
   return <div id="wreckingCrewButtons">
 
@@ -21,6 +27,13 @@ function WreckingCrewButtons() {
       }}>Expert</button>
 
       <article>
+        {/* Cgoob */}
+        {/* <div>
+          {villains.map((villain) => {
+            return <button id={`${villain}${DifficultyHelper.getImageLetter(difficulty)}`} onClick={() => setPhase(`${villain}${DifficultyHelper.getImageLetter(difficulty)}`)}>${(villain)}</button>
+          })}
+        </div> */}
+
         {showNormalButtons && (<div>
           <button id="wreckerA" onClick={() => setPhase("default")}>Wrecker</button>
           <button id="thunderballA" onClick={() => setPhase("thunderballA")}>Thunderball</button> 

--- a/marvel-champions-vt/src/data/Villains.jsx
+++ b/marvel-champions-vt/src/data/Villains.jsx
@@ -1,0 +1,27 @@
+class Villains {
+    db = [
+        {
+            "id": "juggernaut",
+            "name": "Juggernaut",
+            "image": "/blabalbla",
+            "set": ""
+        },
+        {
+            "id": "loki",
+            "name": "Loki",
+            "image": "/blabalbla",
+            "set": "",
+            "phaseButton": <LokiButtons />
+        },
+    ];
+
+    getVillain = function (id) {
+        return this.db[id];
+    }
+
+    getPhaseButton = function (id) {
+        return this.db[id].phaseButton || <GeneralButton />
+    }
+}
+
+export default Villains;

--- a/marvel-champions-vt/src/enum/DifficultyEnum.js
+++ b/marvel-champions-vt/src/enum/DifficultyEnum.js
@@ -1,0 +1,31 @@
+const DifficultyEnum = {
+    Normal: "A",
+    Expert: "B",
+    SuperEasy: "C"
+}
+
+class DifficultyHelper {
+    getImageLetter = function (difficulty) {
+        switch (difficulty) {
+            case DifficultyEnum.Normal:
+                return 'A';
+            case DifficultyEnum.Expert:
+                return 'B';
+            default:
+                return '';
+        }
+    }
+
+    getDifficultyName = function (difficulty) {
+        switch (difficulty) {
+            case DifficultyEnum.Normal:
+                return 'Normal';
+            case DifficultyEnum.Expert:
+                return 'Expert';
+            default:
+                return '';
+        }
+    }
+}
+
+export {DifficultyEnum, DifficultyHelper};

--- a/marvel-champions-vt/src/enum/PhasesEnum.js
+++ b/marvel-champions-vt/src/enum/PhasesEnum.js
@@ -1,0 +1,6 @@
+const PhasesEnum = {
+    A: 'A',
+    B: 'B'
+};
+
+export default PhasesEnum;

--- a/marvel-champions-vt/src/enum/VillainEnum.js
+++ b/marvel-champions-vt/src/enum/VillainEnum.js
@@ -1,0 +1,6 @@
+const VillainEnum = {
+    Juggernaut: "juggernaut",
+    Spiral: "spiral"
+}
+
+export default VillainEnum;

--- a/marvel-champions-vt/src/styles/components/_LokiButtons.scss
+++ b/marvel-champions-vt/src/styles/components/_LokiButtons.scss
@@ -27,7 +27,8 @@
                 }
 
                 button {
-                    padding: 0;
+                    padding: 0 0.5rem;
+                    margin: 0 1rem;
                     height: 50%;
                 }
             }


### PR DESCRIPTION
I didn't want the version we got from Loki when choosing a random Villain to be the same as before. So I added a state to track the actual version and if the randomized version was the same as the earlier one I repeated the process without that version, so it didn't repeat